### PR TITLE
[fix]Fix API documentation build failure due to missing directory

### DIFF
--- a/tools/doc_tool/gen_api.py
+++ b/tools/doc_tool/gen_api.py
@@ -713,6 +713,8 @@ if __name__ == "__main__":
     # generate API documenation according to api_tree
     print("-- Generating MaixCDK API documentation")
     doc_out_dir = args.doc
+    if not os.path.exists(doc_out_dir):
+        os.makedirs(doc_out_dir)
     api_json_path = os.path.join(doc_out_dir, "api.json")
     side_bar_path = os.path.join(doc_out_dir, "sidebar.yaml")
     readme_path = os.path.join(doc_out_dir, "README.md")


### PR DESCRIPTION
Fix API documentation build failure due to missing directory

Resolved an issue where the API documentation build process failed because the necessary directories did not exist. This fix ensures directories are created if they are missing.
