### PR TITLE
fix spi

### DIFF
--- a/components/peripheral/include/maix_spi.hpp
+++ b/components/peripheral/include/maix_spi.hpp
@@ -25,12 +25,12 @@ namespace maix::peripheral::spi
 
     /**
      * Peripheral spi class
-     * 
-     * MaixCAM's SPI1 is a software SPI, 
-     * its device node is /dev/spidev4.0, 
-     * in practice you only need to pass 1 at the parameter id to use it, 
+     *
+     * MaixCAM's SPI1 is a software SPI,
+     * its device node is /dev/spidev4.0,
+     * in practice you only need to pass 1 at the parameter id to use it,
      * and CDK will automatically complete the mapping relationship.
-     * 
+     *
      * @maixpy maix.peripheral.spi.SPI
      */
     class SPI
@@ -50,7 +50,7 @@ namespace maix::peripheral::spi
          * @param[in] cs soft cs pin number, std::string type, default is "GPIOA19", if SPI support multi hardware cs, you can set it to other value.
          * @maixpy maix.peripheral.spi.SPI.__init__
          */
-        SPI(int id, spi::Mode mode, int freq, int polarity = 0, int phase = 0, 
+        SPI(int id, spi::Mode mode, int freq, int polarity = 0, int phase = 0,
             int bits = 8, unsigned char cs_enable=0, bool soft_cs = false, std::string cs = "GPIOA19");
         ~SPI();
 
@@ -58,7 +58,7 @@ namespace maix::peripheral::spi
          * @brief read data from spi
          * @param[in] length read length, int type
          * @return bytes data, Bytes type in C++, bytes type in MaixPy. You need to delete it manually after use in C++.
-         * @maixcdk maix.peripheral.spi.SPI.write
+         * @maixpy maix.peripheral.spi.SPI.read
          */
         Bytes *read(int length);
 
@@ -76,7 +76,7 @@ namespace maix::peripheral::spi
          * the member range of the list is [0,255]
          * @return write length, int type, if write failed, return -err::Err code.
          * @maixcdk maix.peripheral.spi.SPI.write
-         * 
+         *
          */
         int write(std::vector<unsigned char> data);
 
@@ -94,7 +94,6 @@ namespace maix::peripheral::spi
          * @param[in] read_len read length, int type, should > 0.
          * @return read data, vector<unsigned char> type
          * @maixcdk maix.peripheral.spi.SPI.write_read
-         * 
          */
         std::vector<unsigned char> write_read(std::vector<unsigned char> data, int read_len);
 
@@ -103,7 +102,7 @@ namespace maix::peripheral::spi
          * @param[in] data data to write, Bytes type in C++, bytes type in MaixPy
          * @param[in] read_len read length, int type, should > 0.
          * @return read data, Bytes type in C++, bytes type in MaixPy. You need to delete it manually after use in C++.
-         * @maixcdk maix.peripheral.spi.SPI.write_read
+         * @maixpy maix.peripheral.spi.SPI.write_read
          */
         Bytes *write_read(Bytes *data, int read_len);
 

--- a/components/peripheral/include/maix_spi.hpp
+++ b/components/peripheral/include/maix_spi.hpp
@@ -25,12 +25,6 @@ namespace maix::peripheral::spi
 
     /**
      * Peripheral spi class
-     *
-     * MaixCAM's SPI1 is a software SPI,
-     * its device node is /dev/spidev4.0,
-     * in practice you only need to pass 1 at the parameter id to use it,
-     * and CDK will automatically complete the mapping relationship.
-     *
      * @maixpy maix.peripheral.spi.SPI
      */
     class SPI

--- a/components/peripheral/port/maixcam/maix_adc.cpp
+++ b/components/peripheral/port/maixcam/maix_adc.cpp
@@ -18,7 +18,7 @@
 #define DEFAULT_VREF 5.0062
 #define ERR_NEAR_ZERO 0.01
 
-namespace maix::peripheral::adc{   
+namespace maix::peripheral::adc{
 
     ADC::ADC(int pin, int resolution, float vref)
     {
@@ -49,7 +49,6 @@ namespace maix::peripheral::adc{
             _vref = DEFAULT_VREF;
             log::info("ADC default vref:%lf", DEFAULT_VREF);
         }
-            
 
         const char adc_channel[] = "1";
 
@@ -70,7 +69,7 @@ namespace maix::peripheral::adc{
     ADC::~ADC()
     {
         if (_fd > 2) {
-            close(_fd);
+            ::close(_fd);
         }
     }
 

--- a/components/peripheral/port/maixcam/maix_pinmap.cpp
+++ b/components/peripheral/port/maixcam/maix_pinmap.cpp
@@ -17,18 +17,18 @@ namespace maix::peripheral::pinmap
 {
     /**
      * @brief ismod module.ko or rmmod module.ko
-     * 
+     *
      * @param is_install true means insmod, false means rmmod
      * @param dev_node device node, e.g. /dev/spidev4.0
      * @param module_path path to module files, e.g. /mnt/system/ko/,
-     *                      this parameter is ignored if the module is uninstalled. 
-     * @param module_files modules that need to be executed, 
+     *                      this parameter is ignored if the module is uninstalled.
+     * @param module_files modules that need to be executed,
      *                      starting with vector::begin for installing modules and vector::end()-1 for uninstalling modules.
-     * @return err::Err 
+     * @return err::Err
      */
     static inline err::Err __insmod(bool is_install, const std::string& dev_node,
                                     const std::string& module_path, const std::vector<std::string>& module_files)
-    { 
+    {
         if (!is_install) {
             // rmmod
             if (fs::exists(dev_node)) {
@@ -39,10 +39,9 @@ namespace maix::peripheral::pinmap
                         return err::ERR_RUNTIME;
                     }
                 }
-                
             }
             return err::ERR_NONE;
-        } 
+        }
         // insmod
         if (!fs::exists(dev_node)) {
             for (auto& mod : module_files) {
@@ -121,6 +120,7 @@ namespace maix::peripheral::pinmap
             "A27",
             "A28",
             "A29",
+            "B3",
             "P18",
             "P19",
             "P20",
@@ -237,6 +237,13 @@ namespace maix::peripheral::pinmap
                 "UART2_RX",
                 "JTAG_TDO"};
             return funcs;
+        }
+        else if (pin == "B3")
+        {
+            return std::vector<std::string>{
+                "GPIOB3",
+                "ADC"
+            };
         }
         else if (pin == "P18")
         {
@@ -530,6 +537,11 @@ namespace maix::peripheral::pinmap
                 set_pinmux(0x03001074, 0);
             else
                 return err::ERR_ARGS;
+            return err::ERR_NONE;
+        }
+        else if (pin == "B3")
+        {
+            set_pinmux(0x030010F8, 3);
             return err::ERR_NONE;
         }
         else if (pin == "P18")

--- a/components/peripheral/port/maixcam/maix_spi.cpp
+++ b/components/peripheral/port/maixcam/maix_spi.cpp
@@ -31,7 +31,7 @@ namespace maix::peripheral::spi
     {
         int errsv = errno;
         char buffer[64];
-        strerror_r(errsv, buffer, sizeof(buffer));
+        ::strerror_r(errsv, buffer, sizeof(buffer));
         return std::string(buffer);
     }
 
@@ -41,12 +41,12 @@ namespace maix::peripheral::spi
         return err::Exception(err::ERR_RUNTIME, __get_errno_msg());
     }
 
-    static inline int __spi_transfer(int fd, unsigned char used_soft_cs, 
+    static inline int __spi_transfer(int fd, unsigned char used_soft_cs,
                                         unsigned int speed_hz, unsigned char bits,
                                         const uint8_t *txbuf, uint8_t *rxbuf, size_t len) {
         struct spi_ioc_transfer transfer;
 
-        memset(&transfer, 0, sizeof(struct spi_ioc_transfer));
+        ::memset(&transfer, 0, sizeof(struct spi_ioc_transfer));
         transfer.tx_buf = (uintptr_t)txbuf;
         transfer.rx_buf = (uintptr_t)rxbuf;
         transfer.len = len;
@@ -54,20 +54,21 @@ namespace maix::peripheral::spi
         transfer.speed_hz = speed_hz;
         transfer.bits_per_word = bits;
         transfer.cs_change = used_soft_cs;
+        // log::info("[__spi_transfer] cs_change = %d", transfer.cs_change);
 
-        if (ioctl(fd, SPI_IOC_MESSAGE(1), &transfer) < 1)
+        if (::ioctl(fd, SPI_IOC_MESSAGE(1), &transfer) < 1)
             return -1;
 
         return 0;
     }
 
-    SPI::SPI(int id, spi::Mode mode, int freq, int polarity, int phase, 
+    SPI::SPI(int id, spi::Mode mode, int freq, int polarity, int phase,
             int bits, unsigned char cs_enable, bool soft_cs, std::string cs)
                 :_used_soft_cs(soft_cs), _cs_enable(cs_enable), _bits(bits), _freq(freq)
-    {  
+    {
         {
             if (mode == spi::Mode::SLAVE)
-                throw err::Exception(err::ERR_ARGS, "spi::Mode::SLAVE mode not implemented"); 
+                throw err::Exception(err::ERR_ARGS, "spi::Mode::SLAVE mode not implemented");
 
             uint32_t invalid_arguments = (
                 (mode & ~0x01) | (polarity & ~0x01) | (phase & ~0x01));
@@ -77,43 +78,46 @@ namespace maix::peripheral::spi
             if (soft_cs) {
                 auto pull = cs_enable ? gpio::Pull::PULL_DOWN : gpio::Pull::PULL_UP;
                 _cs = new gpio::GPIO(cs, gpio::Mode::OUT, pull);
-                if (nullptr == _cs) 
+                if (nullptr == _cs)
                     throw err::Exception(err::ERR_NO_MEM, "cannot alloc maix::peripheral::gpio");
             } else if (cs_enable != 0) {
-                throw err::Exception(err::ERR_ARGS, "spi:switching the effective level of the default CS " 
+                throw err::Exception(err::ERR_ARGS, "spi:switching the effective level of the default CS "
                                 "is not supported for the time being, if you need a CS pin with an "
                                 "effective level of high, please use the parameter 'cs' to select a "
-                                "GPIO as the CS pin."); 
+                                "GPIO as the CS pin.");
             }
 
             std::string dev_name("/dev/spidev"+std::to_string(id)+".0");
             log::debug("try to open %s...", dev_name.c_str());
             _fd = ::open(dev_name.c_str(), O_RDWR);
-            if (_fd < 0) 
+            if (_fd < 0)
                 throw err::Exception(err::ERR_IO, "cannot open "+dev_name);
         }
 
         uint32_t d8 = ((polarity << 1)|(phase));
-        if (0 != cs_enable) {
+        if (0 != cs_enable && !_used_soft_cs) {
             d8 |= SPI_CS_HIGH;
         }
-        // d8 |= SPI_NO_CS;
-        
-        // log::info("SPI Write Mode: 0x%x", d8);
 
-        if (ioctl(_fd, SPI_IOC_WR_MODE, &d8) < 0) 
+        if (::ioctl(_fd, SPI_IOC_WR_MODE, &d8) < 0)
             throw __ioctl_error(&_fd);
 
-        // if (ioctl(_fd, SPI_IOC_RD_MODE, &d8) < 0)
-        //     throw __ioctl_error(&_fd);
-        // log::info("SPI Read Mode: 0x%x", d8);
-        
-        if (ioctl(_fd, SPI_IOC_WR_MAX_SPEED_HZ, &freq) < 0) 
+        uint32_t rmode = d8;
+        if (::ioctl(_fd, SPI_IOC_RD_MODE, &rmode) < 0)
             throw __ioctl_error(&_fd);
-        
-        if (ioctl(_fd, SPI_IOC_WR_BITS_PER_WORD, &bits) < 0)
-            throw __ioctl_error(&_fd);  
-  
+
+        if (d8 != rmode) {
+            // log::error("SPI Write Mode: 0x%x", d8);
+            // log::error("SPI Read Mode: 0x%x", rmode);
+            // throw err::Exception(err::ERR_WRITE, "SPI write mode failed");
+            log::debug("SPI write MODE: 0x%x, SPI read MODE: 0x%x", d8, rmode);
+        }
+
+        if (::ioctl(_fd, SPI_IOC_WR_MAX_SPEED_HZ, &freq) < 0)
+            throw __ioctl_error(&_fd);
+
+        if (::ioctl(_fd, SPI_IOC_WR_BITS_PER_WORD, &bits) < 0)
+            throw __ioctl_error(&_fd);
     }
 
     SPI::~SPI()
@@ -150,31 +154,41 @@ namespace maix::peripheral::spi
     {
         if (read_len <= 0)
             return std::vector<unsigned char>();
-        
+
         auto w_size = data.size();
         size_t len = std::max(w_size, static_cast<size_t>(read_len));
         if (len != w_size) {
             data.resize(len, 0x00);
         }
 
-        auto rbuf = new unsigned char[len];
-        if (rbuf == nullptr) {
+        auto wbuf = new unsigned char[len];
+        if (nullptr == wbuf) {
             log::error("cannot alloc %d bytes for SPI::write_read", len);
             return std::vector<unsigned char>();
         }
+        ::memset(wbuf, 0x00, len);
+        ::memcpy(wbuf, data.data(), data.size());
 
-        if (_used_soft_cs) 
-            enable_cs(true);
-        if (__spi_transfer(_fd, _used_soft_cs, _freq, _bits, data.data(), rbuf, len) < 0) {
+        auto rbuf = new unsigned char[len];
+        if (nullptr == rbuf) {
+            log::error("cannot alloc %d bytes for SPI::write_read", len);
+            delete[] wbuf;
+            return std::vector<unsigned char>();
+        }
+
+        if (_used_soft_cs)
+            this->enable_cs(true);
+        if (__spi_transfer(_fd, _used_soft_cs, _freq, _bits, wbuf, rbuf, len) < 0) {
+            delete[] wbuf;
             delete[] rbuf;
             return std::vector<unsigned char>();
         }
-        if (_used_soft_cs) 
-            enable_cs(false);
+        if (_used_soft_cs)
+            this->enable_cs(false);
 
         auto res = std::vector<unsigned char>(rbuf, rbuf+read_len);
+        delete[] wbuf;
         delete[] rbuf;
-
         return res;
     }
 
@@ -188,32 +202,35 @@ namespace maix::peripheral::spi
             w_size = data->size();
         size_t len = std::max(w_size, static_cast<size_t>(read_len));
         auto wbuf = new unsigned char[len];
-        memset(wbuf, 0x00, len);
+        if (wbuf == nullptr) {
+            log::error("cannot alloc %d bytes for SPI::write_read", len);
+            return nullptr;
+        }
+        ::memset(wbuf, 0x00, len);
         if (nullptr != data && data->size() > 0) {
             std::copy(data->data, data->data+data->data_len, wbuf);
         }
 
-        auto rbuf = new unsigned char[read_len];
+        auto rbuf = new unsigned char[len];
         if (rbuf == nullptr) {
-            log::error("cannot alloc %d bytes for SPI::write_read", read_len);
+            log::error("cannot alloc %d bytes for SPI::write_read", len);
             delete[] wbuf;
             return nullptr;
         }
 
-        if (_used_soft_cs) 
-            enable_cs(true);
+        if (_used_soft_cs)
+            this->enable_cs(true);
         if (__spi_transfer(_fd, _used_soft_cs, _freq, _bits, wbuf, rbuf, len) < 0) {
             delete[] rbuf;
             delete[] wbuf;
             return nullptr;
         }
-        if (_used_soft_cs) 
-            enable_cs(false);
+        if (_used_soft_cs)
+            this->enable_cs(false);
 
         auto res = new Bytes(rbuf, read_len);
         delete[] wbuf;
         delete[] rbuf;
-
         return res;
     }
 
@@ -224,7 +241,7 @@ namespace maix::peripheral::spi
 
     void SPI::enable_cs(bool enable)
     {
-        if (enable) 
+        if (enable)
             _cs->value(_cs_enable);
         else
             _cs->value(!_cs_enable);

--- a/examples/peripheral_spi/main/src/main.cpp
+++ b/examples/peripheral_spi/main/src/main.cpp
@@ -26,8 +26,8 @@ int _main(int argc, char* argv[])
 
 #ifdef USE_SPI4
     const std::map<std::string, std::string> pin_functions{
-        {"A24", "SPI4_CS"},     /* Default CS of SPI4, currently the valid level of this CS is high 
-                                    and does not support to change, please wait for the fix. 
+        {"A24", "SPI4_CS"},     /* Default CS of SPI4, currently the valid level of this CS is high
+                                    and does not support to change, please wait for the fix.
                                     You can specify another GPIO as the CS pin. */
         {"A23", "SPI4_MISO"},   /* MISO */
         {"A25", "SPI4_MOSI"},   /* MOSI */
@@ -38,7 +38,7 @@ int _main(int argc, char* argv[])
     log::info("Use pinmap to configure SPI4.");
     for (const auto& item : pin_functions) {
         if (err::ERR_NONE != pinmap::set_pin_function(item.first, item.second)) {
-            log::error("Set pin{%s} to function{%s} failed!", 
+            log::error("Set pin{%s} to function{%s} failed!",
                 item.first.c_str(), item.second.c_str());
             return -1;
         }
@@ -60,7 +60,7 @@ int _main(int argc, char* argv[])
     log::info("Use pinmap to configure SPI2.");
     for (const auto& item : pin_functions) {
         if (err::ERR_NONE != pinmap::set_pin_function(item.first, item.second)) {
-            log::error("Set pin{%s} to function{%s} failed!", 
+            log::error("Set pin{%s} to function{%s} failed!",
                 item.first.c_str(), item.second.c_str());
             return -1;
         }


### PR DESCRIPTION
已验证能通过MaixCAM和Linux平台的MaixPy构建&打包。
```bash
sipeed@maixcdk-env:~/MaixPy$ uname -a
Linux maixcdk-env 6.9.4-arch1-1 #1 SMP PREEMPT_DYNAMIC Wed, 12 Jun 2024 20:17:17 +0000 x86_64 x86_64 x86_64 GNU/Linux
sipeed@maixcdk-env:~/MaixPy$ python 
Python 3.11.9 (main, Apr 19 2024, 17:01:14) [GCC 11.2.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> from maix import pinmap, spi, adc
>>> dir(pinmap)
['__doc__', '__loader__', '__name__', '__package__', '__spec__', 'get_pin_functions', 'get_pins', 'set_pin_function']
>>> dir(spi)
['Mode', 'SPI', '__doc__', '__loader__', '__name__', '__package__', '__spec__']
>>> dir(adc)
['ADC', 'RES_BIT_10', 'RES_BIT_12', 'RES_BIT_16', 'RES_BIT_8', '__doc__', '__loader__', '__name__', '__package__', '__spec__']
```