### PR TITLE
Add apt install of  " autoconf automake libtool"

### DIFF
--- a/docs/doc/README.md
+++ b/docs/doc/README.md
@@ -43,7 +43,7 @@ Note that the MaixCAM toolchain only supports x86_64 CPUs and is not compatible 
 
 ```shell
 sudo apt update
-sudo apt install git cmake build-essential python3 python3-pip
+sudo apt install git cmake build-essential python3 python3-pip autoconf automake libtool
 cmake --version # cmake version should be >= 3.13
 ```
 > To compile for a Linux PC (instead of cross-compiling for a dev board), if you’re using `Ubuntu`, ensure the system version is `>=20.04`, or some dependencies may be too outdated to compile. Install dependencies following the commands in the [Dockerfile](https://github.com/sipeed/MaixCDK/blob/main/docs/doc/dev/docker/Dockerfile).

--- a/docs/doc_zh/README.md
+++ b/docs/doc_zh/README.md
@@ -44,7 +44,7 @@ MaixCDK 不光是一套 C++ SDK，同时会自动生成 Python API 绑定，即�
 
 ```
 sudo apt update
-sudo apt install git cmake build-essential python3 python3-pip
+sudo apt install git cmake build-essential python3 python3-pip autoconf automake libtool
 cmake --version # cmake 版本应该 >= 3.13
 ```
 > 如果你希望编译出来到 Linux PC 上跑，而不是交叉编译到开发板，如果是 `Ubuntu`，请使用系统版本`>=20.04`，否则有些依赖包可能会版本太旧无法编译通过，并且按照[Dockerfile](https://github.com/sipeed/MaixCDK/blob/main/docs/doc/dev/docker/Dockerfile)里面的安装依赖的命令来安装依赖。


### PR DESCRIPTION
When I build maixpython in a new env of ubuntu 22.04, An error occurred :

![483cc703c5ccfba81a3c24f5d35d1578](https://github.com/user-attachments/assets/73a82f43-4f14-4ad1-bcb1-6cf4c4f8f515)

I use --verbose to rebuild . It showed that build libmodbus failed while it needed autoreconf tool.

There is no description of env setting up in maixpy build. I think we need to add "autoconf automake libtool" to maixcdk building env setup. 

![692f9a3cbeeadb26acb63eafd628edc0](https://github.com/user-attachments/assets/ef357fc9-7732-41b1-adf9-c6169aad78e2)
