### PR TITLE
fix bug of displaying with width and height of -1 in linux SDL mode.(…

### DIFF
--- a/components/vision/port/linux/maix_display_sdl.hpp
+++ b/components/vision/port/linux/maix_display_sdl.hpp
@@ -82,12 +82,17 @@ namespace maix::display
             {
                 log::warn("screen max supported width: %d, but set %d\n", mode.w, _width);
                 _width = mode.w;
+            }else if(_width == -1){ //fix bug of displaying with width and height of -1 in linux SDL mode
+                _width = mode.w;
             }
             if (_height > mode.h)
             {
                 log::warn("screen max supported height: %d, but set %d\n", mode.h, _height);
                 _height = mode.h;
+            }else if(_height == -1){ //fix bug of displaying with width and height of -1 in linux SDL mode
+                _height = mode.h;
             }
+
             _screen = SDL_CreateWindow("Maix", SDL_WINDOWPOS_UNDEFINED, SDL_WINDOWPOS_UNDEFINED, _width, _height, SDL_WINDOW_SHOWN);
             if (!_screen)
             {


### PR DESCRIPTION
fix bug of displaying with width and height of -1 in linux SDL mode.(user give no width and height ,default is -1). Use display mode width and height to init window.

bug review:

build examples/image_show  in linux mode and run .  it crashed!

I found that ,it crash at :

![image](https://github.com/user-attachments/assets/9c4e63c2-fc00-4cf0-a480-46a748b1d8a0)

while _impl->width() and _impl->height() is -1 . 

that var is init at fun `open` ：

origin code ：

```c
            if (_width > mode.w)
            {
                log::warn("screen max supported width: %d, but set %d\n", mode.w, _width);
                _width = mode.w;
            }
            if (_height > mode.h)
            {
                log::warn("screen max supported height: %d, but set %d\n", mode.h, _height);
                _height = mode.h;
            }
```

I changed to ：
```c
            if (_width > mode.w)
            {
                log::warn("screen max supported width: %d, but set %d\n", mode.w, _width);
                _width = mode.w;
            }else if(_width == -1){
                _width = mode.w;
            }
            if (_height > mode.h)
            {
                log::warn("screen max supported height: %d, but set %d\n", mode.h, _height);
                _height = mode.h;
            }else if(_height == -1){
                _height = mode.h;
            }
```

