### PR TITLE
fix bug of can't exit of sdl display

### DIFF
--- a/components/vision/port/linux/maix_display_sdl.hpp
+++ b/components/vision/port/linux/maix_display_sdl.hpp
@@ -115,9 +115,12 @@ namespace maix::display
         {
             SDL_Display *disp = (SDL_Display *)args_in;
             SDL_Event event;
-            while (1)
+            while (!disp->exit)
             {
-                SDL_WaitEvent(&event);
+                int ret = SDL_WaitEventTimeout(&event,100);
+                if(ret == 0){
+                    continue;
+                }
                 if (event.type == SDL_QUIT)
                 {
                     log::debug("SDL_QUIT\n");


### PR DESCRIPTION
bug: 
   can't exit when ctrl+c .

fix: 
change from : 
![image](https://github.com/user-attachments/assets/8097c033-df9a-4b9a-a4f1-631782806486)
to:
![image](https://github.com/user-attachments/assets/fc9d672c-7402-4242-a8c6-48f4548f0faf)

