### PR TITLE
add zxing support

### DIFF
--- a/components/3rd_party/qrcode/CMakeLists.txt
+++ b/components/3rd_party/qrcode/CMakeLists.txt
@@ -1,8 +1,29 @@
 
-set(version_str "2.1.0")
+set(version_str "2.3.0")
 set(unzip_path "${DL_EXTRACTED_PATH}/zxing-cpp")
 set(src_path "${unzip_path}/zxing-cpp-${version_str}")
-set(file_sha256sum "6d54e403592ec7a143791c6526c1baafddf4c0897bb49b1af72b70a0f0c4a3fe")
+set(file_sha256sum "64e4139103fdbc57752698ee15b5f0b0f7af9a0331ecbdc492047e0772c417ba")
+
+# Ensure ZXing is built with barcode reading support
+set(ZXING_READERS ON CACHE BOOL "Enable barcode reading in ZXing")
+set(ZXING_WRITERS ON CACHE STRING "ON" FORCE)
+set(ZXING_USE_BUNDLED_ZINT ON CACHE BOOL "Use bundled Zint for barcode writing")
+set(ZXING_EXAMPLES OFF CACHE BOOL "Disable ZXing examples")
+set(ZXING_UNIT_TESTS OFF CACHE BOOL "Disable ZXing unit tests")
+set(ZXING_BLACKBOX_TESTS OFF CACHE BOOL "Disable ZXing blackbox tests")
+set(ZXING_PYTHON_MODULE OFF CACHE BOOL "Disable ZXing Python module")
+set(ZXING_C_API OFF CACHE BOOL "Disable ZXing C API")
+set(ZXING_DEPENDENCIES AUTO CACHE STRING "Fetch from github or use locally installed (AUTO/GITHUB/LOCAL)")
+set(BUILD_SHARED_LIBS OFF CACHE BOOL "Build static library")
+
+# Generate Version.h from Version.h.in for ZXing
+configure_file(
+    "${src_path}/core/Version.h.in"
+    "${CMAKE_CURRENT_BINARY_DIR}/Version.h"
+)
+
+# Add build directory to include path for generated Version.h
+list(APPEND ADD_INCLUDE "${CMAKE_CURRENT_BINARY_DIR}")
 
 ################# Add include #################
 list(APPEND ADD_INCLUDE "${src_path}/core/src"

--- a/components/3rd_party/qrcode/component.py
+++ b/components/3rd_party/qrcode/component.py
@@ -5,10 +5,10 @@ def add_file_downloads(confs : dict) -> list:
         @return list type, items is dict type
     '''
     # version = f"{confs['CONFIG_OMV_VERSION_MAJOR']}.{confs['CONFIG_OMV_VERSION_MINOR']}.{confs['CONFIG_OMV_VERSION_PATCH']}"
-    version = "2.1.0"
+    version = "2.3.0"
     url = f"https://github.com/zxing-cpp/zxing-cpp/archive/refs/tags/v{version}.tar.gz"
-    if version == "2.1.0":
-        sha256sum = "6d54e403592ec7a143791c6526c1baafddf4c0897bb49b1af72b70a0f0c4a3fe"
+    if version == "2.3.0":
+        sha256sum = "64e4139103fdbc57752698ee15b5f0b0f7af9a0331ecbdc492047e0772c417ba"
     else:
         raise Exception(f"version {version} not support")
     sites = ['https://www.openssl.org/source/']

--- a/components/vision/CMakeLists.txt
+++ b/components/vision/CMakeLists.txt
@@ -45,7 +45,7 @@ endif()
 
 ###### Add required/dependent components ######
 list(APPEND ADD_REQUIREMENTS basic opencv opencv_freetype websocket peripheral)
-list(APPEND ADD_REQUIREMENTS zbar omv)
+list(APPEND ADD_REQUIREMENTS zbar omv qrcode)
 if(PLATFORM_LINUX)
     list(APPEND ADD_REQUIREMENTS sdl)
 elseif(PLATFORM_MAIXCAM)

--- a/components/vision/include/maix_image.hpp
+++ b/components/vision/include/maix_image.hpp
@@ -1396,8 +1396,11 @@ namespace maix::image
          * @param decoder_type Select the QR code decoding method. Choosing QRCODE_DECODER_TYPE_QUIRC allows for retrieving QR code version, ECC level, mask, data type, and other details,
          * though it may decode slower at lower resolutions. Opting for QRCODE_DECODER_TYPE_ZBAR enables faster decoding at lower resolutions but may slow down at higher resolutions,
          * providing only the QR code content and position information. default is QRCODE_DECODER_TYPE_ZBAR.
-         * Choosing the QRCODE_DECODER_TYPE_ZXING option will use the ZXing library for decoding.
-         * @return Returns the qrcodes of the image
+         * Choosing the QRCODE_DECODER_TYPE_ZXING option will use the ZXing library for decoding. Supports both QRCode and Datamatrix.
+         * Can be used as an alternative to function find_datamatrices to decode Datamatrix codes.
+         * If you find that find_datamatrices is not working well for your Datamatrix codes, you can try using this option instead.
+         * Provides only the QR code/ datamatrix content and position information. default is QRCODE_DECODER_TYPE_ZXING.
+         * @return Returns the qrcodes / (and/or datamatrix for option ZXing) of the image
          * @maixpy maix.image.Image.find_qrcodes
         */
         std::vector<image::QRCode> find_qrcodes(std::vector<int> roi = std::vector<int>(), image::QRCodeDecoderType decoder_type = image::QRCodeDecoderType::QRCODE_DECODER_TYPE_ZBAR);

--- a/components/vision/include/maix_image.hpp
+++ b/components/vision/include/maix_image.hpp
@@ -1396,6 +1396,7 @@ namespace maix::image
          * @param decoder_type Select the QR code decoding method. Choosing QRCODE_DECODER_TYPE_QUIRC allows for retrieving QR code version, ECC level, mask, data type, and other details,
          * though it may decode slower at lower resolutions. Opting for QRCODE_DECODER_TYPE_ZBAR enables faster decoding at lower resolutions but may slow down at higher resolutions,
          * providing only the QR code content and position information. default is QRCODE_DECODER_TYPE_ZBAR.
+         * Choosing the QRCODE_DECODER_TYPE_ZXING option will use the ZXing library for decoding.
          * @return Returns the qrcodes of the image
          * @maixpy maix.image.Image.find_qrcodes
         */

--- a/components/vision/include/maix_image_obj.hpp
+++ b/components/vision/include/maix_image_obj.hpp
@@ -999,7 +999,8 @@ namespace maix::image
     */
     enum class QRCodeDecoderType {
         QRCODE_DECODER_TYPE_ZBAR,
-        QRCODE_DECODER_TYPE_QUIRC
+        QRCODE_DECODER_TYPE_QUIRC,
+        QRCODE_DECODER_TYPE_ZXING
     };
 
     /**

--- a/components/vision/src/maix_image_find_qrcodes.cpp
+++ b/components/vision/src/maix_image_find_qrcodes.cpp
@@ -10,6 +10,8 @@
 #include "zbar.hpp"
 #include "omv.hpp"
 
+#include "ReadBarcode.h" // ZXing main header for barcode reading
+
 namespace maix::image
 {
     static void calculate_rect(const std::vector<int>& vec, int &x, int &y, int &width, int &height) {
@@ -37,142 +39,206 @@ namespace maix::image
         std::vector<image::QRCode> qrcodes;
         std::vector<int> avail_roi = _get_available_roi(roi);
         switch (decoder_type) {
-        case QRCodeDecoderType::QRCODE_DECODER_TYPE_QUIRC:
-        {
-            image_t src_img;
-            Image *gray_img = NULL;
+            case QRCodeDecoderType::QRCODE_DECODER_TYPE_QUIRC:
+            {
+                image_t src_img;
+                Image *gray_img = NULL;
 
-            if (_format == image::FMT_GRAYSCALE) {
-                convert_to_imlib_image(this, &src_img);
-            } else {
-                if (image::FMT_YVU420SP == _format) {
-                    gray_img = new image::Image(_width, _height, image::FMT_GRAYSCALE);
-                    memcpy(gray_img->data(), _data, _width * _height);
+                if (_format == image::FMT_GRAYSCALE) {
+                    convert_to_imlib_image(this, &src_img);
                 } else {
-                    gray_img = this->to_format(image::FMT_GRAYSCALE);
+                    if (image::FMT_YVU420SP == _format) {
+                        gray_img = new image::Image(_width, _height, image::FMT_GRAYSCALE);
+                        memcpy(gray_img->data(), _data, _width * _height);
+                    } else {
+                        gray_img = this->to_format(image::FMT_GRAYSCALE);
+                    }
+                    convert_to_imlib_image(gray_img, &src_img);
                 }
-                convert_to_imlib_image(gray_img, &src_img);
+
+                rectangle_t roi_rect;
+                std::vector<int> avail_roi = _get_available_roi(roi);
+                roi_rect.x = avail_roi[0];
+                roi_rect.y = avail_roi[1];
+                roi_rect.w = avail_roi[2];
+                roi_rect.h = avail_roi[3];
+
+                // This code is used to fix imlib_find_qrcodes crash bug, but this is a terrible fix
+                if (roi_rect.x == 0 && roi_rect.y == 0 && roi_rect.w == src_img.w && roi_rect.h == src_img.h) {
+                    roi_rect.x = 1;
+                    roi_rect.y = 1;
+                    roi_rect.w = src_img.w - 2;
+                    roi_rect.h = src_img.h - 2;
+                }
+
+                list_t out;
+                imlib_find_qrcodes(&out, &src_img, &roi_rect);
+                for (size_t i = 0; list_size(&out); i ++) {
+                    find_qrcodes_list_lnk_data_t lnk_data;
+                    list_pop_front(&out, &lnk_data);
+
+                    std::vector<int> rect = {
+                        (int)lnk_data.rect.x,
+                        (int)lnk_data.rect.y,
+                        (int)lnk_data.rect.w,
+                        (int)lnk_data.rect.h,
+                    };
+                    std::vector<std::vector<int>> corners = {
+                        {(int)lnk_data.corners[0].x, (int)lnk_data.corners[0].y},
+                        {(int)lnk_data.corners[1].x, (int)lnk_data.corners[1].y},
+                        {(int)lnk_data.corners[2].x, (int)lnk_data.corners[2].y},
+                        {(int)lnk_data.corners[3].x, (int)lnk_data.corners[3].y},
+                    };
+
+                    std::string payload;
+                    payload.assign(lnk_data.payload, lnk_data.payload_len);
+                    xfree(lnk_data.payload);
+                    image::QRCode qrcode(rect,
+                                        corners,
+                                        payload,
+                                        lnk_data.version,
+                                        lnk_data.ecc_level,
+                                        lnk_data.mask,
+                                        lnk_data.data_type,
+                                        lnk_data.eci);
+                    qrcodes.push_back(qrcode);
+                }
+
+                if (_format != image::FMT_GRAYSCALE) {
+                    delete gray_img;
+                }
+
+                break;
             }
-
-            rectangle_t roi_rect;
-            std::vector<int> avail_roi = _get_available_roi(roi);
-            roi_rect.x = avail_roi[0];
-            roi_rect.y = avail_roi[1];
-            roi_rect.w = avail_roi[2];
-            roi_rect.h = avail_roi[3];
-
-            // This code is used to fix imlib_find_qrcodes crash bug, but this is a terrible fix
-            if (roi_rect.x == 0 && roi_rect.y == 0 && roi_rect.w == src_img.w && roi_rect.h == src_img.h) {
-                roi_rect.x = 1;
-                roi_rect.y = 1;
-                roi_rect.w = src_img.w - 2;
-                roi_rect.h = src_img.h - 2;
-            }
-
-            list_t out;
-            imlib_find_qrcodes(&out, &src_img, &roi_rect);
-            for (size_t i = 0; list_size(&out); i ++) {
-                find_qrcodes_list_lnk_data_t lnk_data;
-                list_pop_front(&out, &lnk_data);
-
-                std::vector<int> rect = {
-                    (int)lnk_data.rect.x,
-                    (int)lnk_data.rect.y,
-                    (int)lnk_data.rect.w,
-                    (int)lnk_data.rect.h,
-                };
-                std::vector<std::vector<int>> corners = {
-                    {(int)lnk_data.corners[0].x, (int)lnk_data.corners[0].y},
-                    {(int)lnk_data.corners[1].x, (int)lnk_data.corners[1].y},
-                    {(int)lnk_data.corners[2].x, (int)lnk_data.corners[2].y},
-                    {(int)lnk_data.corners[3].x, (int)lnk_data.corners[3].y},
-                };
-
-                std::string payload;
-                payload.assign(lnk_data.payload, lnk_data.payload_len);
-                xfree(lnk_data.payload);
-                image::QRCode qrcode(rect,
-                                    corners,
-                                    payload,
-                                    lnk_data.version,
-                                    lnk_data.ecc_level,
-                                    lnk_data.mask,
-                                    lnk_data.data_type,
-                                    lnk_data.eci);
-                qrcodes.push_back(qrcode);
-            }
-
-            if (_format != image::FMT_GRAYSCALE) {
-                delete gray_img;
-            }
-
-            break;
-        }
-        case QRCodeDecoderType::QRCODE_DECODER_TYPE_ZBAR:
-        {
-            bool need_delete_gray_img = false;
-            bool need_delete_new_img = false;
-            Image *gray_img = NULL;
-            if (_format == image::FMT_GRAYSCALE) {
-                gray_img = this;
-            } else {
-                if (image::FMT_YVU420SP == _format) {
-                    gray_img = new image::Image(_width, _height, image::FMT_GRAYSCALE);
-                    memcpy(gray_img->data(), _data, _width * _height);
+            case QRCodeDecoderType::QRCODE_DECODER_TYPE_ZBAR:
+            {
+                bool need_delete_gray_img = false;
+                bool need_delete_new_img = false;
+                Image *gray_img = NULL;
+                if (_format == image::FMT_GRAYSCALE) {
+                    gray_img = this;
                 } else {
-                    gray_img = this->to_format(image::FMT_GRAYSCALE);
+                    if (image::FMT_YVU420SP == _format) {
+                        gray_img = new image::Image(_width, _height, image::FMT_GRAYSCALE);
+                        memcpy(gray_img->data(), _data, _width * _height);
+                    } else {
+                        gray_img = this->to_format(image::FMT_GRAYSCALE);
+                    }
+                    need_delete_gray_img = true;
                 }
-                need_delete_gray_img = true;
-            }
-            image::Image *new_img = NULL;
-            if (avail_roi[0] != 0 || avail_roi[1] != 0 || avail_roi[2] != gray_img->width() || avail_roi[3] != gray_img->height()) {
-                new_img = gray_img->crop(avail_roi[0], avail_roi[1], avail_roi[2], avail_roi[3]);
-                need_delete_new_img = true;
-            } else {
-                new_img = gray_img;
-            }
-
-            zbar_qrcode_result_t result;
-            zbar_scan_qrcode_in_gray((uint8_t *)new_img->data(), new_img->width(), new_img->height(), &result);
-            for (int i = 0; i < result.counter; i ++) {
-                for (size_t j = 0; j < result.corners[i].size(); j += 2) {
-                    result.corners[i][j] += avail_roi[0];
-                    result.corners[i][j + 1] += avail_roi[1];
+                image::Image *new_img = NULL;
+                if (avail_roi[0] != 0 || avail_roi[1] != 0 || avail_roi[2] != gray_img->width() || avail_roi[3] != gray_img->height()) {
+                    new_img = gray_img->crop(avail_roi[0], avail_roi[1], avail_roi[2], avail_roi[3]);
+                    need_delete_new_img = true;
+                } else {
+                    new_img = gray_img;
                 }
-                int x, y, w, h;
-                calculate_rect(result.corners[i], x, y, w, h);
-                std::vector<int> rect = {
-                    (int)x,
-                    (int)y,
-                    (int)w,
-                    (int)h,
-                };
-                std::vector<std::vector<int>> corners = {
-                    {(int)result.corners[i][0], (int)result.corners[i][1]},
-                    {(int)result.corners[i][6], (int)result.corners[i][7]},
-                    {(int)result.corners[i][4], (int)result.corners[i][5]},
-                    {(int)result.corners[i][2], (int)result.corners[i][3]},
-                };
-                std::string payload = result.data[i];
-                image::QRCode qrcode(rect,
-                                    corners,
-                                    payload,
-                                    0,
-                                    0,
-                                    0,
-                                    0,
-                                    0);
-                qrcodes.push_back(qrcode);
-            }
-            if (need_delete_gray_img) {
-                delete gray_img;
-            }
 
-            if (need_delete_new_img) {
-                delete new_img;
+                zbar_qrcode_result_t result;
+                zbar_scan_qrcode_in_gray((uint8_t *)new_img->data(), new_img->width(), new_img->height(), &result);
+                for (int i = 0; i < result.counter; i ++) {
+                    for (size_t j = 0; j < result.corners[i].size(); j += 2) {
+                        result.corners[i][j] += avail_roi[0];
+                        result.corners[i][j + 1] += avail_roi[1];
+                    }
+                    int x, y, w, h;
+                    calculate_rect(result.corners[i], x, y, w, h);
+                    std::vector<int> rect = {
+                        (int)x,
+                        (int)y,
+                        (int)w,
+                        (int)h,
+                    };
+                    std::vector<std::vector<int>> corners = {
+                        {(int)result.corners[i][0], (int)result.corners[i][1]},
+                        {(int)result.corners[i][6], (int)result.corners[i][7]},
+                        {(int)result.corners[i][4], (int)result.corners[i][5]},
+                        {(int)result.corners[i][2], (int)result.corners[i][3]},
+                    };
+                    std::string payload = result.data[i];
+                    image::QRCode qrcode(rect,
+                                        corners,
+                                        payload,
+                                        0,
+                                        0,
+                                        0,
+                                        0,
+                                        0);
+                    qrcodes.push_back(qrcode);
+                }
+                if (need_delete_gray_img) {
+                    delete gray_img;
+                }
+
+                if (need_delete_new_img) {
+                    delete new_img;
+                }
+                break;
             }
-            break;
-        }
+            case QRCodeDecoderType::QRCODE_DECODER_TYPE_ZXING:
+            {
+                // ZXing QR code detection using ZXing-C++ 2.1.0
+                bool need_delete_gray_img = false;
+                bool need_delete_new_img = false;
+                Image *gray_img = NULL;
+                if (_format == image::FMT_GRAYSCALE) {
+                    gray_img = this;
+                } else {
+                    if (image::FMT_YVU420SP == _format) {
+                        gray_img = new image::Image(_width, _height, image::FMT_GRAYSCALE);
+                        memcpy(gray_img->data(), _data, _width * _height);
+                    } else {
+                        gray_img = this->to_format(image::FMT_GRAYSCALE);
+                    }
+                    need_delete_gray_img = true;
+                }
+                image::Image *new_img = NULL;
+                if (avail_roi[0] != 0 || avail_roi[1] != 0 || avail_roi[2] != gray_img->width() || avail_roi[3] != gray_img->height()) {
+                    new_img = gray_img->crop(avail_roi[0], avail_roi[1], avail_roi[2], avail_roi[3]);
+                    need_delete_new_img = true;
+                } else {
+                    new_img = gray_img;
+                }
+
+                // ZXing expects a grayscale buffer, so we use new_img->data()
+                ZXing::ImageView zxing_img((const uint8_t*)new_img->data(), new_img->width(), new_img->height(), ZXing::ImageFormat::Lum);
+                ZXing::DecodeHints hints;
+                hints.setTryHarder(true);
+                hints.setFormats(ZXing::BarcodeFormat::QRCode | ZXing::BarcodeFormat::DataMatrix);
+                auto result = ZXing::ReadBarcode(zxing_img, hints);
+                if (result.isValid()) {
+                    // Get bounding box and corners
+                    auto points = result.position();
+                    std::vector<int> rect;
+                    int min_x = INT32_MAX, min_y = INT32_MAX, max_x = 0, max_y = 0;
+                    std::vector<std::vector<int>> corners;
+                    for (const auto& pt : points) {
+                        min_x = std::min(min_x, (int)pt.x);
+                        min_y = std::min(min_y, (int)pt.y);
+                        max_x = std::max(max_x, (int)pt.x);
+                        max_y = std::max(max_y, (int)pt.y);
+                        corners.push_back({(int)pt.x + avail_roi[0], (int)pt.y + avail_roi[1]});
+                    }
+                    rect = {min_x + avail_roi[0], min_y + avail_roi[1], max_x - min_x, max_y - min_y};
+                    std::string payload = result.text();
+                    image::QRCode qrcode(rect,
+                                        corners,
+                                        payload,
+                                        0,
+                                        0,
+                                        0,
+                                        0,
+                                        0);
+                    qrcodes.push_back(qrcode);
+                }
+                if (need_delete_gray_img) {
+                    delete gray_img;
+                }
+                if (need_delete_new_img) {
+                    delete new_img;
+                }
+                break;
+            }
         }
 
         return qrcodes;

--- a/components/vision/src/maix_image_find_qrcodes.cpp
+++ b/components/vision/src/maix_image_find_qrcodes.cpp
@@ -177,7 +177,7 @@ namespace maix::image
             }
             case QRCodeDecoderType::QRCODE_DECODER_TYPE_ZXING:
             {
-                // ZXing QR code detection using ZXing-C++ 2.1.0
+                // ZXing QR code detection using ZXing-C++ 2.3.0
                 bool need_delete_gray_img = false;
                 bool need_delete_new_img = false;
                 Image *gray_img = NULL;


### PR DESCRIPTION
This Pr adds support for ZXing library inside existing function find_qrcodes.
- it adds enum QRCODE_DECODER_TYPE_ZXING to configure the Qrcode decoding using ZXing instead of the default one QRCODE_DECODER_TYPE_ZBAR.
- It implements Zxing librairy Qrcode decoding and also Datamatrix decoding.
- Documentation header has also been updated.
- version of Zxing has also been updates from 2.1.0 up to 2.3.0 where it brings optimisation on datamatrix decoding when the image is oriented around 45°. (see Zxing release note (https://github.com/zxing-cpp/zxing-cpp/releases) for a full list of changes and improvements.