### PR TITLE
docs: update device SSH credentials

### DIFF
--- a/docs/doc/README.md
+++ b/docs/doc/README.md
@@ -115,14 +115,14 @@ Use `scp` to copy files, for example:
 ```shell
 scp -r dist/ root@10.127.117.1:/root/
 ```
-The default password is `root`.
+The SSH username is `root` on these devices. The default password is `root` on MaixCAM/MaixCAM-Pro and `sipeed` on MaixCAM2.
 
 ### Running the Program
 
 Run the program via SSH. Ensure no other programs are running (including the startup application launcher).
 Steps:
 * Connect MaixVision to the device to close the Launcher, or use SSH to `kill` the `launcher_daemon`.
-* SSH into the device, e.g., `ssh root@192.168.0.123`, password `root`.
+* SSH into the device, e.g., `ssh root@192.168.0.123`. Use username `root`; the password is `root` for MaixCAM/MaixCAM-Pro or `sipeed` for MaixCAM2.
 * Navigate to the executable directory and run it, e.g., `cd /root/dist/camera_display_release && ./camera_display`.
 
 ### Packaging for Release
@@ -176,4 +176,3 @@ namespace maix::example
 Then compile the `MaixPy` project to get an installation package, which can be installed on the device to use the new API—simple, right?
 
 For more detailed documentation, refer to [Add API](./convention/add_api.md).
-

--- a/docs/doc_zh/README.md
+++ b/docs/doc_zh/README.md
@@ -118,14 +118,14 @@ maixcdk build
 ```shell
 scp -r dist/ root@10.127.117.1:/root/
 ```
-默认密码是`root`
+设备的 SSH 用户名均为 `root`；MaixCAM/MaixCAM-Pro 默认密码为 `root`，MaixCAM2 默认密码为 `sipeed`。
 
 ### 运行
 
 通过 ssh 终端运行程序。注意要保证没有程序正在运行（包括开机的应用选择界面(Launcher)）。
 具体方法：
 * MaixVision 连接设备，这会让 Launcher 退出。也可以在 ssh 终端手动`kill` `launcher_daemon`程序。（**重要!!**）
-* ssh 连接设备，比如 `ssh root@192.168.0.123`， 密码是 `root`。
+* ssh 连接设备，比如 `ssh root@192.168.0.123`。用户名为 `root`；MaixCAM/MaixCAM-Pro 密码为 `root`，MaixCAM2 密码为 `sipeed`。
 * 然后到可知性文件目录下执行文件， 比如 `cd /root/dist/camera_display_release && ./camera_display`
 
 ### 打包发布
@@ -181,5 +181,4 @@ namespace maix::example
 ## 开发准则
 
 要开始使用 MaixCDK，请从阅读[MaixCDK 开发准则](./convention/README.md) 开始。
-
 


### PR DESCRIPTION
  ## Summary

  Update the Quick Start documentation to clarify SSH credentials for different MaixCAM devices.

  ## Changes

  - Clarify that MaixCAM/MaixCAM-Pro use username `root` and password `root`.
  - Clarify that MaixCAM2 uses username `root` and password `sipeed`.
  - Sync the same credential guidance in both Chinese and English docs.

  ## Testing

  - Previewed the docs locally with `teedoc serve`.
  - Verified the updated Chinese and English pages contain the new SSH credential text.