### PR TITLE
feat(maixcam2): support OS04D10 640x360@120fps

### DIFF
--- a/components/maixcam_lib/include/maixcam2/ax_middleware.hpp
+++ b/components/maixcam_lib/include/maixcam2/ax_middleware.hpp
@@ -522,6 +522,7 @@ namespace maix::middleware::maixcam2 {
         SAMPLE_VIN_SINGLE_OS04D10 = 4,
         SAMPLE_VIN_SINGLE_SC850SL_1080P60 = 5,
         SAMPLE_VIN_SINGLE_OS04D10_720P60 = 6,
+        SAMPLE_VIN_SINGLE_OS04D10_360P120 = 7,
         SAMPLE_VIN_BUTT
     } SAMPLE_VIN_CASE_E;
 
@@ -652,6 +653,133 @@ namespace maix::middleware::maixcam2 {
         .tCompressInfo = {AX_COMPRESS_MODE_LOSSY, 4},
         .tFrameRateCtrl = {AX_INVALID_FRMRATE, AX_INVALID_FRMRATE},
     };
+
+    static AX_MIPI_RX_ATTR_T gOs04d10_360P120_MipiAttr = {
+        .ePhyMode = AX_MIPI_PHY_TYPE_DPHY,
+        .eLaneNum = AX_MIPI_DATA_LANE_2,
+        .nDataRate = 720,
+        .nDataLaneMap = {2, 1, -1, -1},
+        .nClkLane = {0, 5},
+    };
+
+    static AX_SNS_ATTR_T gOs04d10_360P120_SnsAttr = {
+        .nWidth = 640,
+        .nHeight = 360,
+        .fFrameRate = 120,
+        .eSnsMode = AX_SNS_LINEAR_MODE,
+        .eRawType = AX_RT_RAW10,
+        .eBayerPattern = AX_BP_BGGR,
+        .bTestPatternEnable = AX_FALSE,
+    };
+
+    static AX_VIN_DEV_ATTR_T gOs04d10_360P120_DevAttr = {
+        .eDevMode = AX_VIN_DEV_ONLINE,
+        .bImgDataEnable = AX_TRUE,
+        .bNonImgDataEnable = AX_FALSE,
+        .eSnsIntfType = AX_SNS_INTF_TYPE_MIPI_RAW,
+        .eSnsMode = AX_SNS_LINEAR_MODE,
+        .eBayerPattern = AX_BP_BGGR,
+        .ePixelFmt = AX_FORMAT_BAYER_RAW_10BPP_PACKED,
+        .tDevImgRgn = {{0, 0, 640, 360},
+                        {0, 0, 640, 360},
+                        {0, 0, 640, 360},
+                        {0, 0, 640, 360},},
+        .eSnsOutputMode = AX_SNS_NORMAL,
+        .tFrameRateCtrl = {AX_INVALID_FRMRATE, AX_INVALID_FRMRATE},
+        .tCompressInfo = {AX_COMPRESS_MODE_NONE, 0},
+    };
+
+    static AX_VIN_PIPE_ATTR_T gOs04d10_360P120_PipeAttr = {
+        .ePipeWorkMode = AX_VIN_PIPE_NORMAL_MODE1,
+        .tPipeImgRgn = {0, 0, 640, 360},
+        .nWidthStride = 640,
+        .eBayerPattern = AX_BP_BGGR,
+        .ePixelFmt = AX_FORMAT_BAYER_RAW_10BPP_PACKED,
+        .eSnsMode = AX_SNS_LINEAR_MODE,
+        .tCompressInfo = {AX_COMPRESS_MODE_LOSSY, 0},
+        .tNrAttr = {{AX_FALSE, {AX_COMPRESS_MODE_LOSSLESS, 0}}, {AX_FALSE, {AX_COMPRESS_MODE_NONE, 0}}},
+        .tFrameRateCtrl = {AX_INVALID_FRMRATE, AX_INVALID_FRMRATE},
+    };
+
+    static AX_VIN_CHN_ATTR_T gOs04d10_360P120_Chn0Attr = {
+        .nWidth = 640,
+        .nHeight = 360,
+        .nWidthStride = 640,
+        .eImgFormat = AX_FORMAT_YUV420_SEMIPLANAR,
+        .nDepth = 2,
+        .tCompressInfo = {AX_COMPRESS_MODE_LOSSY, 4},
+        .tFrameRateCtrl = {AX_INVALID_FRMRATE, AX_INVALID_FRMRATE},
+    };
+
+    static AX_SENSOR_REGISTER_FUNC_T gOs04d10_360P120_SnsObj = {};
+    static AX_VOID (*gOs04d10_360P120_OriginalInit)(ISP_PIPE_ID) = nullptr;
+    static AX_S32 (*gOs04d10_360P120_OriginalSetFps)(ISP_PIPE_ID, AX_F32) = nullptr;
+    static AX_S32 (*gOs04d10_360P120_OriginalWriteReg)(ISP_PIPE_ID, AX_U32, AX_U32) = nullptr;
+    static AX_S32 (*gOs04d10_360P120_OriginalGetHwExposure)(ISP_PIPE_ID, AX_SNS_EXP_CTRL_PARAM_T *) = nullptr;
+    static AX_S32 (*gOs04d10_360P120_OriginalGetIntegrationRange)(ISP_PIPE_ID, AX_F32, AX_SNS_AE_INT_TIME_RANGE_T *) = nullptr;
+
+    static AX_VOID __os04d10_360p120_init(ISP_PIPE_ID pipe)
+    {
+        if (!gOs04d10_360P120_OriginalInit) {
+            return;
+        }
+        gOs04d10_360P120_OriginalInit(pipe);
+        if (gOs04d10_360P120_OriginalWriteReg) {
+            // The vendor sensor object has no public 360p120 entry, so select the
+            // mode after its regular initialization without modifying the object.
+            AX_S32 ret = gOs04d10_360P120_OriginalWriteReg(pipe, 0xfd, 0x00);
+            if (ret != AX_SUCCESS) {
+                log::error("OS04D10 360p120 page select failed, ret=0x%x", ret);
+            }
+            ret = gOs04d10_360P120_OriginalWriteReg(pipe, 0x20, 0x03);
+            if (ret != AX_SUCCESS) {
+                log::error("OS04D10 360p120 mode select failed, ret=0x%x", ret);
+            }
+        }
+    }
+
+    static AX_S32 __os04d10_360p120_set_fps(ISP_PIPE_ID pipe, AX_F32 fps)
+    {
+        if (fps == 120.0f) {
+            return 0;
+        }
+        return gOs04d10_360P120_OriginalSetFps ? gOs04d10_360P120_OriginalSetFps(pipe, fps) : -1;
+    }
+
+    static AX_S32 __os04d10_360p120_get_hw_exposure(ISP_PIPE_ID pipe, AX_SNS_EXP_CTRL_PARAM_T *param)
+    {
+        int ret = gOs04d10_360P120_OriginalGetHwExposure ?
+                  gOs04d10_360P120_OriginalGetHwExposure(pipe, param) : -1;
+        if (ret == 0) {
+            // The vendor object reports the 30 FPS limit (1457 lines) for this hidden mode.
+            // At 120 FPS one frame is about 368 lines, so keep blanking margin and cap at 360.
+            param->sns_ae_limit.tIntTimeRange.fMaxIntegrationTime[0] = 360.0f;
+            if (param->fInitIntegrationTime < 1.0f) {
+                param->fInitIntegrationTime = 4.0f;
+            }
+            if (param->sns_ae_param.fCurIntegrationTime[0] < 1.0f) {
+                param->sns_ae_param.fCurIntegrationTime[0] = 4.0f;
+            }
+        }
+        return ret;
+    }
+
+    static AX_S32 __os04d10_360p120_get_integration_range(ISP_PIPE_ID pipe, AX_F32 ratio,
+                                                           AX_SNS_AE_INT_TIME_RANGE_T *range)
+    {
+        int ret = gOs04d10_360P120_OriginalGetIntegrationRange ?
+                  gOs04d10_360P120_OriginalGetIntegrationRange(pipe, ratio, range) : -1;
+        if (ret == 0 && range->fMaxIntegrationTime[0] > 360.0f) {
+            range->fMaxIntegrationTime[0] = 360.0f;
+        }
+        return ret;
+    }
+
+    static AX_S32 __os04d10_360p120_set_slow_fps(ISP_PIPE_ID, AX_F32)
+    {
+        // Slow shutter changes the sensor timing to 30 FPS, so it is not allowed in this mode.
+        return 0;
+    }
 
     // SC850SL
     static COMMON_SYS_POOL_CFG_T gtSysCommPoolSingleSc850slSdr[] = {
@@ -1021,6 +1149,61 @@ namespace maix::middleware::maixcam2 {
         return 0;
     }
 
+    static AX_U32 __sample_case_single_os04d10_360p120(AX_CAMERA_T *pCamList, SAMPLE_SNS_TYPE_E eSnsType,
+        SAMPLE_VIN_PARAM_T *pVinParam, COMMON_SYS_ARGS_T *pCommonArgs)
+    {
+        AX_CAMERA_T *pCam = NULL;
+        COMMON_VIN_MODE_E eSysMode = pVinParam->eSysMode;
+        AX_SNS_HDR_MODE_E eHdrMode = pVinParam->eHdrMode;
+        AX_S32 j = 0;
+        pCommonArgs->nCamCnt = 1;
+        pCam = &pCamList[0];
+        COMMON_VIN_GetSnsConfig(eSnsType, &pCam->tMipiAttr, &pCam->tSnsAttr,
+                                &pCam->tSnsClkAttr, &pCam->tDevAttr,
+                                &pCam->tPipeAttr[pCam->nPipeId], pCam->tChnAttr);
+        ::memcpy(&pCam->tMipiAttr, &gOs04d10_360P120_MipiAttr, sizeof(pCam->tMipiAttr));
+        ::memcpy(&pCam->tSnsAttr, &gOs04d10_360P120_SnsAttr, sizeof(pCam->tSnsAttr));
+        ::memcpy(&pCam->tDevAttr, &gOs04d10_360P120_DevAttr, sizeof(pCam->tDevAttr));
+        ::memcpy(&pCam->tPipeAttr[pCam->nPipeId], &gOs04d10_360P120_PipeAttr, sizeof(pCam->tPipeAttr[pCam->nPipeId]));
+        ::memcpy(&pCam->tChnAttr, &gOs04d10_360P120_Chn0Attr, sizeof(pCam->tChnAttr));
+        pCam->nDevId = 0;
+        pCam->nRxDev = 0;
+        pCam->nPipeId = 0;
+        pCam->nI2cAddr = 0x3c;
+        pCam->tSnsClkAttr.nSnsClkIdx = 0;
+        pCam->tDevBindPipe.nNum = 1;
+        pCam->eSnsType = eSnsType;
+        pCam->tDevBindPipe.nPipeId[0] = pCam->nPipeId;
+        AX_SENSOR_REGISTER_FUNC_T *sns_obj = COMMON_ISP_GetSnsObj(eSnsType);
+        if (!sns_obj) {
+            log::error("Get OS04D10 sensor object for 360p120 failed");
+            return -1;
+        }
+        ::memcpy(&gOs04d10_360P120_SnsObj, sns_obj, sizeof(gOs04d10_360P120_SnsObj));
+        gOs04d10_360P120_OriginalInit = gOs04d10_360P120_SnsObj.pfn_sensor_init;
+        gOs04d10_360P120_OriginalSetFps = gOs04d10_360P120_SnsObj.pfn_sensor_set_fps;
+        gOs04d10_360P120_OriginalWriteReg = gOs04d10_360P120_SnsObj.pfn_sensor_write_register;
+        gOs04d10_360P120_OriginalGetHwExposure = gOs04d10_360P120_SnsObj.pfn_sensor_get_hw_exposure_params;
+        gOs04d10_360P120_OriginalGetIntegrationRange = gOs04d10_360P120_SnsObj.pfn_sensor_get_integration_time_range;
+        gOs04d10_360P120_SnsObj.pfn_sensor_init = __os04d10_360p120_init;
+        gOs04d10_360P120_SnsObj.pfn_sensor_set_fps = __os04d10_360p120_set_fps;
+        gOs04d10_360P120_SnsObj.pfn_sensor_get_hw_exposure_params = __os04d10_360p120_get_hw_exposure;
+        gOs04d10_360P120_SnsObj.pfn_sensor_get_integration_time_range = __os04d10_360p120_get_integration_range;
+        gOs04d10_360P120_SnsObj.pfn_sensor_set_slow_fps = __os04d10_360p120_set_slow_fps;
+        pCam->ptSnsHdl[pCam->nPipeId] = &gOs04d10_360P120_SnsObj;
+        pCam->eBusType = COMMON_ISP_GetSnsBusType(eSnsType);
+        pCam->eLaneComboMode = AX_LANE_COMBO_MODE_1;
+        __set_pipe_hdr_mode(&pCam->tDevBindPipe.nHDRSel[0], eHdrMode);
+        __set_vin_attr(pCam, eSnsType, eHdrMode, eSysMode, AX_FALSE);
+        for (j = 0; j < (AX_S32)pCam->tDevBindPipe.nNum; j++) {
+            pCam->tPipeInfo[j].ePipeMode = SAMPLE_PIPE_MODE_VIDEO;
+            pCam->tPipeInfo[j].bAiispEnable = AX_FALSE;
+            strncpy(pCam->tPipeInfo[j].szBinPath, "/opt/etc/os04d10_sipeed_sdr_2lane_720p60.bin",
+                    sizeof(pCam->tPipeInfo[j].szBinPath));
+        }
+        return 0;
+    }
+
     static AX_U32 __sample_case_single_os04d10(AX_CAMERA_T *pCamList, SAMPLE_SNS_TYPE_E eSnsType,
         SAMPLE_VIN_PARAM_T *pVinParam, COMMON_SYS_ARGS_T *pCommonArgs)
     {
@@ -1223,6 +1406,21 @@ namespace maix::middleware::maixcam2 {
             /* cams config */
             __sample_case_single_os04d10_720p60(pCamList, eSnsType, pVinParam, pCommonArgs);
         break;
+        case SAMPLE_VIN_SINGLE_OS04D10_360P120:
+            eSnsType = OMNIVISION_OS04D10;
+            /* comm pool config */
+            __cal_dump_pool(gtSysCommPoolSingleOs04d10Sdr, pVinParam->eHdrMode, pVinParam->nDumpFrameNum);
+            pCommonArgs->nPoolCfgCnt = sizeof(gtSysCommPoolSingleOs04d10Sdr) / sizeof(gtSysCommPoolSingleOs04d10Sdr[0]);
+            pCommonArgs->pPoolCfg = gtSysCommPoolSingleOs04d10Sdr;
+
+            /* private pool config */
+            __cal_dump_pool(gtPrivatePoolSingleOs04d10Sdr, pVinParam->eHdrMode, pVinParam->nDumpFrameNum);
+            pPrivArgs->nPoolCfgCnt = sizeof(gtPrivatePoolSingleOs04d10Sdr) / sizeof(gtPrivatePoolSingleOs04d10Sdr[0]);
+            pPrivArgs->pPoolCfg = gtPrivatePoolSingleOs04d10Sdr;
+
+            /* cams config */
+            __sample_case_single_os04d10_360p120(pCamList, eSnsType, pVinParam, pCommonArgs);
+        break;
         case SAMPLE_VIN_SINGLE_SC850SL:
             eSnsType = SMARTSENS_SC850SL;
             /* comm pool config */
@@ -1317,7 +1515,12 @@ namespace maix::middleware::maixcam2 {
             }
 
             if (fps > 30 || fps <= 0) {
-                if (w > 1280 || h > 720) {
+                if (fps == 120 && w == 640 && h == 360) {
+                    w = 640;
+                    h = 360;
+                    fps = 120;
+                    return SAMPLE_VIN_SINGLE_OS04D10_360P120;
+                } else if (w > 1280 || h > 720) {
                     w = 2560;
                     h = 1440;
                     fps = 30;

--- a/components/vision/port/maixcam2/maix_camera_maixcam2.cpp
+++ b/components/vision/port/maixcam2/maix_camera_maixcam2.cpp
@@ -26,6 +26,58 @@ namespace maix::camera
     static bool __invert_flip = false;
     static bool __invert_mirror = false;
 
+    static AX_S32 __config_os04d10_360p120_ae(AX_U8 pipe)
+    {
+        AX_ISP_IQ_AE_PARAM_T param = {};
+        AX_S32 ret = AX_ISP_IQ_GetAeParam(pipe, &param);
+        if (ret != AX_SUCCESS) {
+            return ret;
+        }
+
+        param.nEnable = false;
+        param.tExpManual.nShutter = 4000;
+        param.tExpManual.nShortShutter = 250;
+        param.tExpManual.nVsShutter = 4000;
+        ret = AX_ISP_IQ_SetAeParam(pipe, &param);
+        if (ret != AX_SUCCESS) {
+            return ret;
+        }
+
+        ret = AX_ISP_IQ_GetAeParam(pipe, &param);
+        if (ret != AX_SUCCESS) {
+            return ret;
+        }
+        param.nEnable = false;
+        param.tExpManual.nAGain = 1024;
+        ret = AX_ISP_IQ_SetAeParam(pipe, &param);
+        if (ret != AX_SUCCESS) {
+            return ret;
+        }
+
+        ret = AX_ISP_IQ_GetAeParam(pipe, &param);
+        if (ret != AX_SUCCESS) {
+            return ret;
+        }
+        AX_ISP_IQ_AE_ALG_CONFIG_T &config = param.tAeAlgAuto;
+        config.nCompensationMode = 0;
+        config.nMaxIspGain = 1024;
+        config.nMinIspGain = 1024;
+        config.nMaxUserDgain = 1024;
+        config.nMinUserDgain = 1024;
+        config.nMaxUserTotalAgain = 15872;
+        config.nMinUserTotalAgain = 1024;
+        config.nMaxUserSysGain = 16384;
+        config.nMinUserSysGain = 1024;
+        config.nMaxShutter = 8000;
+        config.nMinShutter = 361;
+        config.nStrategyMode = 0;
+        config.nAeRouteMode = 0;
+        config.tAntiFlickerParam.nAntiFlickerMode = 0;
+        config.tSlowShutterParam.nFrameRateMode = 0;
+        param.nEnable = true;
+        return AX_ISP_IQ_SetAeParam(pipe, &param);
+    }
+
     std::vector<std::string> list_devices()
     {
         log::warn("This device is not driven using device files!");
@@ -609,6 +661,12 @@ namespace maix::camera
 
         this->vflip(priv->chn.vflip);
         this->hmirror(priv->chn.mirror);
+        if (tVinParam.eSysCase == SAMPLE_VIN_SINGLE_OS04D10_360P120) {
+            AX_S32 ret = __config_os04d10_360p120_ae(0);
+            if (ret != AX_SUCCESS) {
+                log::error("Configure OS04D10 360p120 AE failed, ret=0x%x", ret);
+            }
+        }
         return err::ERR_NONE;
     }
 

--- a/examples/os04d10_120_test/README.md
+++ b/examples/os04d10_120_test/README.md
@@ -1,0 +1,59 @@
+# OS04D10 120 FPS test
+
+This MaixCAM2-only test requests the OS04D10 native 640x360@120 sensor mode. It
+does not open the display by default. It counts successful camera reads and prints AXERA
+VIN device, pipe, and channel frame rates and loss counters. It also reports the
+actual AE shutter, gain, FPS and measured image luma once per second. AI-ISP is disabled;
+the regular ISP remains enabled because OS04D10 outputs RAW10 and RGB/YUV frames
+need the regular ISP pipeline.
+
+The new sensor mode is selected only for an exact `640x360@120` request. All
+other OS04D10 resolution and frame-rate requests keep the original MaixCDK mode
+selection behavior.
+
+Build:
+
+    maixcdk build -p maixcam2 --toolchain-id default
+
+Run NV21 for the default 10 seconds, or pass a duration in seconds:
+
+    ./os04d10_120_test
+    ./os04d10_120_test 30
+
+Pass `rgb` as the second argument to request RGB888 frames:
+
+    ./os04d10_120_test 30 rgb
+
+Pass `display` as the third argument to show every frame and measure the display
+call overhead and resulting loop rate:
+
+    ./os04d10_120_test 30 rgb display
+    ./os04d10_120_test 30 nv21 display
+
+The 120 FPS mode constrains automatic exposure to 361-8000 us, uses shutter
+priority, and limits system gain to 16x so AE does not oscillate between its
+minimum and the 720p60 tuning file's original 2048x limit. Automatic exposure
+is enabled by default. The optional fourth and fifth arguments switch to manual
+exposure in microseconds and analog gain in U22.10 units (`1024` is 1x). Keep
+exposure below one 120 FPS frame period:
+
+    ./os04d10_120_test 10 nv21 display 7500 1024
+
+Pass `0 0`, or omit both values, to use automatic exposure:
+
+    ./os04d10_120_test 10 nv21 display 0 0
+
+On the tested MaixCAM2, `Display::show()` accepts about 120 input frames per
+second without blocking the camera loop to the panel refresh rate. The built-in
+panel runs at about 59.27 Hz, so VO replaces intermediate frames and physically
+outputs about 59 frames per second even though the application loop stays near
+120 FPS.
+
+## Known limitations
+
+The closed-source OS04D10 sensor object does not expose a public 640x360@120
+entry, so this mode applies a verified register override after the vendor's
+normal initialization. It also reuses the official 720p60 ISP tuning file.
+Consequently, image quality can be lower than 720p60 and artificial lighting can
+show visible flicker. Manual exposure can reduce the effect for a specific light
+source, but it is not a general anti-flicker calibration for this sensor mode.

--- a/examples/os04d10_120_test/app.yaml
+++ b/examples/os04d10_120_test/app.yaml
@@ -1,0 +1,8 @@
+id: os04d10_120_test
+name: OS04D10 120 FPS Test
+name[zh]: OS04D10 120帧测试
+version: 1.0.0
+author: chaoxiaohan
+desc: Verify OS04D10 640x360 at 120 FPS, automatic exposure and optional display throughput
+desc[zh]: 验证 OS04D10 的 640x360 120帧模式、自动曝光和可选显示吞吐量
+files: {}

--- a/examples/os04d10_120_test/main/CMakeLists.txt
+++ b/examples/os04d10_120_test/main/CMakeLists.txt
@@ -1,0 +1,4 @@
+list(APPEND ADD_INCLUDE "include")
+append_srcs_dir(ADD_SRCS "src")
+list(APPEND ADD_REQUIREMENTS vision)
+register_component()

--- a/examples/os04d10_120_test/main/Kconfig
+++ b/examples/os04d10_120_test/main/Kconfig
@@ -1,0 +1,1 @@
+# No custom configuration.

--- a/examples/os04d10_120_test/main/src/main.cpp
+++ b/examples/os04d10_120_test/main/src/main.cpp
@@ -1,0 +1,255 @@
+#include "maix_basic.hpp"
+
+#if PLATFORM_MAIXCAM2
+
+#include "maix_camera.hpp"
+#include "maix_display.hpp"
+#include "ax_isp_3a_api.h"
+#include "ax_vin_api.h"
+
+#include <cstdlib>
+#include <string>
+
+using namespace maix;
+
+static void print_vin_status(int channel)
+{
+    AX_VIN_DEV_STATUS_T dev_status = {};
+    AX_VIN_PIPE_STATUS_T pipe_status = {};
+    AX_VIN_CHN_STATUS_T chn_status = {};
+
+    int dev_ret = AX_VIN_QueryDevStatus(0, &dev_status);
+    int pipe_ret = AX_VIN_QueryPipeStatus(0, &pipe_status);
+    int chn_ret = AX_VIN_QueryChnStatus(0, static_cast<AX_VIN_CHN_ID_E>(channel), &chn_status);
+
+    if (dev_ret == 0) {
+        log::info("VIN dev: enabled=%d fps=%.2f seq=%llu lost=%u vb_fail=%u",
+                  dev_status.bEnable, dev_status.fFrameRate,
+                  static_cast<unsigned long long>(dev_status.nFrameSeqNum),
+                  dev_status.nLostFrameCnt, dev_status.nVbFailCnt);
+    } else {
+        log::error("AX_VIN_QueryDevStatus failed: 0x%x", dev_ret);
+    }
+
+    if (pipe_ret == 0) {
+        log::info("VIN pipe: enabled=%d fps=%.2f seq=%llu lost=%u vb_fail=%u",
+                  pipe_status.bEnable, pipe_status.fFrameRate,
+                  static_cast<unsigned long long>(pipe_status.nFrameSeqNum),
+                  pipe_status.nLostFrameCnt, pipe_status.nVbFailCnt);
+    } else {
+        log::error("AX_VIN_QueryPipeStatus failed: 0x%x", pipe_ret);
+    }
+
+    if (chn_ret == 0) {
+        log::info("VIN ch%d: enabled=%d fps=%.2f seq=%llu lost=%u vb_fail=%u",
+                  channel, chn_status.bEnable, chn_status.fFrameRate,
+                  static_cast<unsigned long long>(chn_status.nFrameSeqNum),
+                  chn_status.nLostFrameCnt, chn_status.nVbFailCnt);
+    } else {
+        log::error("AX_VIN_QueryChnStatus failed: 0x%x", chn_ret);
+    }
+}
+
+static void print_ae_limits()
+{
+    AX_ISP_IQ_EXP_HW_LIMIT_T limits = {};
+    int ret = AX_ISP_IQ_GetAeHwLimit(0, &limits);
+    if (ret != 0) {
+        log::error("AX_ISP_IQ_GetAeHwLimit failed: 0x%x", ret);
+        return;
+    }
+
+    log::info("AE limits: shutter=%u..%u us slow_shutter=%u..%u us",
+              limits.tSnsShutterLimit.nMin, limits.tSnsShutterLimit.nMax,
+              limits.tSnsSlowShutterModeShutterLimit.nMin,
+              limits.tSnsSlowShutterModeShutterLimit.nMax);
+    log::info("AE gain limits: again=%.2f..%.2fx dgain=%.2f..%.2fx isp=%.2f..%.2fx total=%.2f..%.2fx",
+              limits.tSnsAgainLimit.nMin / 1024.0, limits.tSnsAgainLimit.nMax / 1024.0,
+              limits.tSnsDgainLimit.nMin / 1024.0, limits.tSnsDgainLimit.nMax / 1024.0,
+              limits.tIspDgainLimit.nMin / 1024.0, limits.tIspDgainLimit.nMax / 1024.0,
+              limits.nTotalGainMin / 1024.0, limits.nTotalGainMax / 1024.0);
+}
+
+static void print_ae_status(double image_luma)
+{
+    AX_ISP_IQ_AE_STATUS_T status = {};
+    AX_ISP_IQ_AE_PARAM_T param = {};
+    int ret = AX_ISP_IQ_GetAeStatus(0, &status);
+    if (ret != 0) {
+        log::error("AX_ISP_IQ_GetAeStatus failed: 0x%x", ret);
+        return;
+    }
+
+    const AX_ISP_IQ_EXP_SETTING_T &exp = status.tExpStatus;
+    const AX_ISP_IQ_AE_ALG_STATUS_T &alg = status.tAlgStatus;
+    ret = AX_ISP_IQ_GetAeParam(0, &param);
+    if (ret == 0) {
+        const AX_ISP_IQ_AE_ALG_CONFIG_T &config = param.tAeAlgAuto;
+        log::info("AE mode: %s manual_shutter=%u us manual_again=%.2fx manual_total=%.2fx",
+                  param.nEnable ? "auto" : "manual", param.tExpManual.nShutter,
+                  param.tExpManual.nAGain / 1024.0, param.tExpManual.nSysTotalGain / 1024.0);
+        log::info("AE config: strategy=%u compensation=%u shutter=%u..%u us again=%.2f..%.2fx dgain=%.2f..%.2fx isp=%.2f..%.2fx sys=%.2f..%.2fx",
+                  config.nStrategyMode, config.nCompensationMode,
+                  config.nMinShutter, config.nMaxShutter,
+                  config.nMinUserTotalAgain / 1024.0, config.nMaxUserTotalAgain / 1024.0,
+                  config.nMinUserDgain / 1024.0, config.nMaxUserDgain / 1024.0,
+                  config.nMinIspGain / 1024.0, config.nMaxIspGain / 1024.0,
+                  config.nMinUserSysGain / 1024.0, config.nMaxUserSysGain / 1024.0);
+    }
+    log::info("AE actual: shutter=%u us again=%.2fx dgain=%.2fx isp=%.2fx total=%.2fx fps=%.2f stable=%u",
+              exp.nShutter, exp.nAGain / 1024.0, exp.nDgain / 1024.0,
+              exp.nIspGain / 1024.0, exp.nSysTotalGain / 1024.0,
+              alg.nFps / 1024.0, alg.nAeStable);
+    log::info("AE luma: mean=%.1f weighted=%.1f target=%.1f sampled_image=%.1f",
+              alg.nMeanLuma / 1024.0, alg.nWeightedMeanLuma / 1024.0,
+              alg.nFrameTarget / 1024.0, image_luma);
+}
+
+static double measure_luma(image::Image &img)
+{
+    const uint8_t *data = static_cast<const uint8_t *>(img.data());
+    uint64_t sum = 0;
+    uint64_t count = 0;
+
+    if (img.format() == image::Format::FMT_YVU420SP) {
+        int pixels = img.width() * img.height();
+        for (int i = 0; i < pixels; i += 16) {
+            sum += data[i];
+            ++count;
+        }
+    } else if (img.format() == image::Format::FMT_RGB888) {
+        int pixels = img.width() * img.height();
+        for (int i = 0; i < pixels; i += 16) {
+            int offset = i * 3;
+            sum += (77 * data[offset] + 150 * data[offset + 1] + 29 * data[offset + 2]) >> 8;
+            ++count;
+        }
+    }
+
+    return count ? static_cast<double>(sum) / count : -1.0;
+}
+
+static int run_test(int argc, char *argv[])
+{
+    uint64_t duration_ms = 10000;
+    if (argc > 1) {
+        long seconds = std::strtol(argv[1], nullptr, 10);
+        if (seconds > 0) {
+            duration_ms = static_cast<uint64_t>(seconds) * 1000;
+        }
+    }
+
+    bool rgb888 = argc > 2 && std::string(argv[2]) == "rgb";
+    bool use_display = argc > 3 && std::string(argv[3]) == "display";
+    int manual_exposure_us = argc > 4 ? std::strtol(argv[4], nullptr, 10) : 0;
+    int manual_again = argc > 5 ? std::strtol(argv[5], nullptr, 10) : 0;
+    image::Format format = rgb888 ? image::Format::FMT_RGB888 : image::Format::FMT_YVU420SP;
+    log::info("Opening OS04D10 test mode: 640x360 %s @ 120 FPS, display=%s, AI-ISP disabled",
+              rgb888 ? "RGB888" : "NV21", use_display ? "on" : "off");
+    camera::Camera cam(640, 360, format, "", 120, 4, true, false);
+    display::Display *disp = use_display ? new display::Display() : nullptr;
+    log::info("Camera accepted: %dx%d @ %.2f FPS, channel=%d, buffers=%d",
+              cam.width(), cam.height(), cam.fps(), cam.get_channel(), cam.buff_num());
+    if (disp) {
+        log::info("Display opened: %dx%d %s", disp->width(), disp->height(),
+                  image::format_name(disp->format()).c_str());
+    }
+    if (manual_exposure_us > 0) {
+        log::info("Set manual exposure: requested=%d us result=%d us",
+                  manual_exposure_us, cam.exposure(manual_exposure_us));
+    }
+    if (manual_again > 0) {
+        log::info("Set manual analog gain: requested=%d/1024 result_total=%d/1024",
+                  manual_again, cam.gain(manual_again));
+    }
+
+    print_vin_status(cam.get_channel());
+    print_ae_limits();
+
+    uint64_t start_ms = time::ticks_ms();
+    uint64_t next_report_ms = start_ms + 1000;
+    uint64_t frame_count = 0;
+    uint64_t timeout_count = 0;
+    uint64_t display_count = 0;
+    uint64_t display_fail_count = 0;
+    uint64_t display_time_us = 0;
+    double image_luma = -1.0;
+
+    while (!app::need_exit() && time::ticks_ms() - start_ms < duration_ms) {
+        image::Image *img = cam.read(true, 1000);
+        if (img) {
+            if (frame_count == 0) {
+                log::info("First frame: %dx%d %s, data=%d bytes", img->width(), img->height(),
+                          image::format_name(img->format()).c_str(), img->data_size());
+            }
+            if (frame_count % 30 == 0) {
+                image_luma = measure_luma(*img);
+            }
+            if (disp) {
+                uint64_t show_start_us = time::ticks_us();
+                err::Err show_ret = disp->show(*img, image::FIT_CONTAIN);
+                display_time_us += time::ticks_us() - show_start_us;
+                if (show_ret == err::ERR_NONE) {
+                    ++display_count;
+                } else {
+                    ++display_fail_count;
+                }
+            }
+            ++frame_count;
+            delete img;
+        } else {
+            ++timeout_count;
+        }
+
+        uint64_t now_ms = time::ticks_ms();
+        if (now_ms >= next_report_ms) {
+            double read_fps = frame_count * 1000.0 / (now_ms - start_ms);
+            log::info("Read progress: frames=%llu timeouts=%llu average=%.2f FPS",
+                      static_cast<unsigned long long>(frame_count),
+                      static_cast<unsigned long long>(timeout_count), read_fps);
+            if (disp) {
+                log::info("Display progress: shown=%llu failed=%llu average_show=%.3f ms",
+                          static_cast<unsigned long long>(display_count),
+                          static_cast<unsigned long long>(display_fail_count),
+                          display_count ? display_time_us / display_count / 1000.0 : 0.0);
+            }
+            print_vin_status(cam.get_channel());
+            print_ae_status(image_luma);
+            next_report_ms = now_ms + 1000;
+        }
+    }
+
+    uint64_t elapsed_ms = time::ticks_ms() - start_ms;
+    double read_fps = elapsed_ms ? frame_count * 1000.0 / elapsed_ms : 0.0;
+    log::info("FINAL: frames=%llu elapsed=%llu ms timeouts=%llu measured_read_fps=%.2f",
+              static_cast<unsigned long long>(frame_count),
+              static_cast<unsigned long long>(elapsed_ms),
+              static_cast<unsigned long long>(timeout_count), read_fps);
+    if (disp) {
+        log::info("DISPLAY_FINAL: shown=%llu failed=%llu measured_loop_fps=%.2f average_show=%.3f ms",
+                  static_cast<unsigned long long>(display_count),
+                  static_cast<unsigned long long>(display_fail_count),
+                  elapsed_ms ? display_count * 1000.0 / elapsed_ms : 0.0,
+                  display_count ? display_time_us / display_count / 1000.0 : 0.0);
+        delete disp;
+    }
+    print_vin_status(cam.get_channel());
+    print_ae_status(image_luma);
+    return frame_count ? 0 : -1;
+}
+
+int main(int argc, char *argv[])
+{
+    sys::register_default_signal_handle();
+    CATCH_EXCEPTION_RUN_RETURN(run_test, -1, argc, argv);
+}
+
+#else
+
+int main()
+{
+    maix::log::warn("os04d10_120_test only supports MaixCAM2");
+    return 0;
+}
+
+#endif


### PR DESCRIPTION
## Description

Add a 640x360@120fps mode for the OS04D10 camera on MaixCAM2.

The mode is enabled only for an exact \`640x360@120fps\` request. Other resolutions and frame rates keep the original behavior. AI-ISP is disabled, and the auto-exposure range is adjusted for this mode.

A test example is included for capture FPS, auto exposure and display output.

## Test

- MaixCAM2 cross-compilation passed
- NV21 and RGB888 tested
- Capture rate is about 120 FPS
- Auto exposure and display output tested

## Known issue

This mode reuses the OS04D10 720p60 ISP parameters, so image quality and anti-flicker performance are not as good as the official 720p60 mode.